### PR TITLE
[feat] 전시회 리뷰 작성 api

### DIFF
--- a/src/main/java/hyangyu/server/api/ReviewApi.java
+++ b/src/main/java/hyangyu/server/api/ReviewApi.java
@@ -1,0 +1,55 @@
+package hyangyu.server.api;
+
+import hyangyu.server.domain.Display;
+import hyangyu.server.domain.User;
+import hyangyu.server.dto.ErrorDto;
+import hyangyu.server.dto.RequestReviewDto;
+import hyangyu.server.dto.SaveReviewResponseDto;
+import hyangyu.server.service.DisplayReviewService;
+import hyangyu.server.service.DisplayService;
+import hyangyu.server.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReviewApi {
+
+    private final DisplayReviewService displayReviewService;
+    private final DisplayService displayService;
+    private final UserService userService;
+
+    @PostMapping("/review/display/{displayId}")
+    public ResponseEntity saveDisplayReview(@PathVariable Long displayId, @RequestBody RequestReviewDto requestReviewDto) throws Exception {
+        // jwt 해독 코드 추후 추가
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //전시 검색
+        Optional<Display> display = displayService.findOne(displayId);
+        if(display.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(400, "잘못된 전시 번호입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if(user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(400, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //리뷰 저장
+        int count = displayReviewService.saveDisplayReview(userId, displayId, requestReviewDto);
+        if (count == 0) {
+            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.");
+            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
+        } else {
+            return new ResponseEntity(new ErrorDto(400, "이미 전시에 대한 리뷰를 달았습니다."), HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/hyangyu/server/config/SecurityConfig.java
+++ b/src/main/java/hyangyu/server/config/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 	                .antMatchers("/api/AuthController/authenticate").permitAll()
 	                .antMatchers("/api/UserApi/signup").permitAll()
 					.antMatchers("/api/display/{displayId}").permitAll()
+					.antMatchers("/api/review/display/{displayId}").permitAll()
 	                .anyRequest().authenticated()
 
 	                .and()

--- a/src/main/java/hyangyu/server/domain/DisplayReview.java
+++ b/src/main/java/hyangyu/server/domain/DisplayReview.java
@@ -42,13 +42,14 @@ public class DisplayReview {
     private Integer score;
 
     // 생성 메서드
-    public void saveDisplayReview(Long reviewId, User user, Display display, String nickname, LocalDateTime createTime, String content, Integer score) {
-        this.reviewId = reviewId;
-        this.user = user;
-        this.display = display;
-        this.nickname = nickname;
-        this.createTime = createTime;
-        this.content = content;
-        this.score = score;
+    public static DisplayReview createDisplayReview(User user, Display display, String nickname, LocalDateTime createTime, String content, Integer score) {
+        DisplayReview displayReview = new DisplayReview();
+        displayReview.user = user;
+        displayReview.display = display;
+        displayReview.nickname = nickname;
+        displayReview.createTime = createTime;
+        displayReview.content = content;
+        displayReview.score = score;
+        return displayReview;
     }
 }

--- a/src/main/java/hyangyu/server/domain/FairReview.java
+++ b/src/main/java/hyangyu/server/domain/FairReview.java
@@ -45,13 +45,14 @@ public class FairReview {
     private Integer score;
 
     // 생성 메서드
-    public void saveFairReview(Long reviewId, User user, Fair fair, String nickname, LocalDateTime createTime, String content, Integer score) {
-        this.reviewId = reviewId;
-        this.user = user;
-        this.fair = fair;
-        this.nickname = nickname;
-        this.createTime = createTime;
-        this.content = content;
-        this.score = score;
+    public static FairReview createFairReview(User user, Fair fair, String nickname, LocalDateTime createTime, String content, Integer score) {
+        FairReview fairReview = new FairReview();
+        fairReview.user = user;
+        fairReview.fair = fair;
+        fairReview.nickname = nickname;
+        fairReview.createTime = createTime;
+        fairReview.content = content;
+        fairReview.score = score;
+        return fairReview;
     }
 }

--- a/src/main/java/hyangyu/server/domain/FestivalReview.java
+++ b/src/main/java/hyangyu/server/domain/FestivalReview.java
@@ -45,13 +45,14 @@ public class FestivalReview {
     private Integer score;
 
     // 생성 메서드
-    public void saveFestivalReview(Long reviewId, User user, Festival festival, String nickname, LocalDateTime createTime, String content, Integer score) {
-        this.reviewId = reviewId;
-        this.user = user;
-        this.festival = festival;
-        this.nickname = nickname;
-        this.createTime = createTime;
-        this.content = content;
-        this.score = score;
+    public static FestivalReview createFestivalReview(User user, Festival festival, String nickname, LocalDateTime createTime, String content, Integer score) {
+        FestivalReview festivalReview = new FestivalReview();
+        festivalReview.user = user;
+        festivalReview.festival = festival;
+        festivalReview.nickname = nickname;
+        festivalReview.createTime = createTime;
+        festivalReview.content = content;
+        festivalReview.score = score;
+        return festivalReview;
     }
 }

--- a/src/main/java/hyangyu/server/dto/RequestReviewDto.java
+++ b/src/main/java/hyangyu/server/dto/RequestReviewDto.java
@@ -1,0 +1,13 @@
+package hyangyu.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestReviewDto {
+    private String content;
+    private int score;
+}

--- a/src/main/java/hyangyu/server/dto/SaveReviewResponseDto.java
+++ b/src/main/java/hyangyu/server/dto/SaveReviewResponseDto.java
@@ -1,0 +1,11 @@
+package hyangyu.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SaveReviewResponseDto {
+    int status;
+    String message;
+}

--- a/src/main/java/hyangyu/server/repository/DisplayReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/DisplayReviewRepository.java
@@ -1,0 +1,7 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.DisplayReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DisplayReviewRepository extends JpaRepository<DisplayReview, Long> {
+}

--- a/src/main/java/hyangyu/server/repository/DisplayReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/DisplayReviewRepository.java
@@ -2,6 +2,12 @@ package hyangyu.server.repository;
 
 import hyangyu.server.domain.DisplayReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DisplayReviewRepository extends JpaRepository<DisplayReview, Long> {
+
+    @Query("select count(r) from DisplayReview r where r.display.displayId=?1 and r.user.userId=?2")
+    public int getCount(Long diplayId, Long userId);
 }

--- a/src/main/java/hyangyu/server/repository/FairReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/FairReviewRepository.java
@@ -1,0 +1,7 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.FairReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FairReviewRepository extends JpaRepository<FairReview, Long> {
+}

--- a/src/main/java/hyangyu/server/repository/FairReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/FairReviewRepository.java
@@ -2,6 +2,10 @@ package hyangyu.server.repository;
 
 import hyangyu.server.domain.FairReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FairReviewRepository extends JpaRepository<FairReview, Long> {
+
+    @Query("select count(r) from FairReview r where r.fair.fairId=?1 and r.user.userId=?2")
+    public int findReview(Long fairId, Long userId);
 }

--- a/src/main/java/hyangyu/server/repository/FestivalReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/FestivalReviewRepository.java
@@ -2,6 +2,10 @@ package hyangyu.server.repository;
 
 import hyangyu.server.domain.FestivalReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FestivalReviewRepository extends JpaRepository<FestivalReview, Long> {
+
+    @Query("select count(r) from FestivalReview r where r.festival.festivalId=?1 and r.user.userId=?2")
+    public int getCount(Long festivalId, Long userId);
 }

--- a/src/main/java/hyangyu/server/repository/FestivalReviewRepository.java
+++ b/src/main/java/hyangyu/server/repository/FestivalReviewRepository.java
@@ -1,0 +1,7 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.FestivalReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalReviewRepository extends JpaRepository<FestivalReview, Long> {
+}

--- a/src/main/java/hyangyu/server/service/DisplayReviewService.java
+++ b/src/main/java/hyangyu/server/service/DisplayReviewService.java
@@ -1,0 +1,38 @@
+package hyangyu.server.service;
+
+import hyangyu.server.domain.Display;
+import hyangyu.server.domain.DisplayReview;
+import hyangyu.server.domain.User;
+import hyangyu.server.dto.RequestReviewDto;
+import hyangyu.server.repository.DisplayRepository;
+import hyangyu.server.repository.DisplayReviewRepository;
+import hyangyu.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DisplayReviewService {
+
+    private final DisplayReviewRepository displayReviewRepository;
+    private final UserRepository userRepository;
+    private final DisplayRepository displayRepository;
+
+    @Transactional(readOnly = false)
+    public int saveDisplayReview(Long userId, Long displayId, RequestReviewDto requestReviewDto) {
+        Optional<User> user = userRepository.findById(userId);
+        Optional<Display> display = displayRepository.findOne(displayId);
+        int count = displayReviewRepository.getCount(display.get().getDisplayId(), user.get().getUserId());
+        if (count == 0) {
+            DisplayReview displayReview = DisplayReview.createDisplayReview(user.get(), display.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore());
+            displayReviewRepository.save(displayReview);
+        }
+        return count;
+    }
+}

--- a/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
@@ -1,0 +1,49 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.Display;
+import hyangyu.server.domain.DisplayReview;
+import hyangyu.server.domain.User;
+import hyangyu.server.dto.EventDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.sql.Date;
+import java.sql.Time;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class DisplayReviewTest {
+
+    @Autowired
+    DisplayReviewRepository displayReviewRepository;
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("전시회 리뷰 저장")
+    void saveDisplayReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "전시제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
+        Display display = Display.createDisplay(eventDto);
+        em.persist(display);
+
+        //when
+        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        DisplayReview savedDisplayReview = displayReviewRepository.save(displayReview);
+
+        //then
+        assertEquals(displayReview, savedDisplayReview);
+        assertEquals(displayReview.getReviewId(), savedDisplayReview.getReviewId());
+    }
+}

--- a/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
@@ -4,7 +4,6 @@ import hyangyu.server.domain.Display;
 import hyangyu.server.domain.DisplayReview;
 import hyangyu.server.domain.User;
 import hyangyu.server.dto.EventDto;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +15,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -31,7 +31,7 @@ class DisplayReviewTest {
     @DisplayName("전시회 리뷰 저장")
     void saveDisplayReview() throws Exception {
         //given
-        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
         em.persist(user);
 
         EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "전시제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
@@ -41,9 +41,11 @@ class DisplayReviewTest {
         //when
         DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
         DisplayReview savedDisplayReview = displayReviewRepository.save(displayReview);
+        int count = displayReviewRepository.getCount(display.getDisplayId(), user.getUserId());
 
         //then
         assertEquals(displayReview, savedDisplayReview);
         assertEquals(displayReview.getReviewId(), savedDisplayReview.getReviewId());
+        assertThat(count).isEqualTo(1);
     }
 }

--- a/src/test/java/hyangyu/server/repository/FairReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FairReviewTest.java
@@ -2,6 +2,7 @@ package hyangyu.server.repository;
 
 import hyangyu.server.domain.*;
 import hyangyu.server.dto.EventDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -29,7 +31,7 @@ class FairReviewTest {
     @DisplayName("박람회 리뷰 저장")
     void saveFairReview() throws Exception {
         //given
-        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
         em.persist(user);
 
         EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
@@ -39,9 +41,11 @@ class FairReviewTest {
         //when
         FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
         FairReview savedFairReview = fairReviewRepository.save(fairReview);
+        int count = fairReviewRepository.findReview(fair.getFairId(), user.getUserId());
 
         //then
         assertEquals(fairReview, savedFairReview);
         assertEquals(fairReview.getReviewId(), savedFairReview.getReviewId());
+        assertThat(count).isEqualTo(1);
     }
 }

--- a/src/test/java/hyangyu/server/repository/FairReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FairReviewTest.java
@@ -1,0 +1,47 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.*;
+import hyangyu.server.dto.EventDto;
+import org.junit.jupiter.api.DisplayName;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.sql.Date;
+import java.sql.Time;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class FairReviewTest {
+
+    @Autowired
+    FairReviewRepository fairReviewRepository;
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("박람회 리뷰 저장")
+    void saveFairReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
+        Fair fair = Fair.createFair(eventDto);
+        em.persist(fair);
+
+        //when
+        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FairReview savedFairReview = fairReviewRepository.save(fairReview);
+
+        //then
+        assertEquals(fairReview, savedFairReview);
+        assertEquals(fairReview.getReviewId(), savedFairReview.getReviewId());
+    }
+}

--- a/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
@@ -1,0 +1,46 @@
+package hyangyu.server.repository;
+
+import hyangyu.server.domain.*;
+import hyangyu.server.dto.EventDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.sql.Date;
+import java.sql.Time;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class FestivalReviewTest {
+
+    @Autowired
+    FestivalReviewRepository festivalReviewRepository;
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("페스티벌 리뷰 저장")
+    void saveFestivalReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
+        Festival festival = Festival.createFestival(eventDto);
+        em.persist(festival);
+
+        //when
+        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FestivalReview savedFestivalReview = festivalReviewRepository.save(festivalReview);
+
+        //then
+        assertEquals(festivalReview, savedFestivalReview);
+        assertEquals(festivalReview.getReviewId(), savedFestivalReview.getReviewId());
+    }
+}

--- a/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
@@ -2,6 +2,7 @@ package hyangyu.server.repository;
 
 import hyangyu.server.domain.*;
 import hyangyu.server.dto.EventDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -28,7 +30,7 @@ class FestivalReviewTest {
     @DisplayName("페스티벌 리뷰 저장")
     void saveFestivalReview() throws Exception {
         //given
-        User user = User.createUser("test@naver.com", "test1234", "향유", "token");
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
         em.persist(user);
 
         EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", Date.valueOf("2021-01-01"), "내용", "사진1", "사진2", "사진3", 20000);
@@ -38,9 +40,11 @@ class FestivalReviewTest {
         //when
         FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
         FestivalReview savedFestivalReview = festivalReviewRepository.save(festivalReview);
+        int count = festivalReviewRepository.getCount(festival.getFestivalId(), user.getUserId());
 
         //then
         assertEquals(festivalReview, savedFestivalReview);
         assertEquals(festivalReview.getReviewId(), savedFestivalReview.getReviewId());
+        assertThat(count).isEqualTo(1);
     }
 }


### PR DESCRIPTION
# 전시회 리뷰 작성 api
## 공지사항
1. 전시회, 박람회, 축제 repository랑 repositoryTest는 우선 만들어뒀는데, service & api 코드는 전시회 리뷰 저장만 만들었어! 박람회, 축제 리뷰 저장은 새로운 이슈 파서 하게 될 것 같아
2. token 해독하는 코드 알게 되면 추후에 수정할게!

## 포스트맨 테스트
### 성공
<img width="745" alt="스크린샷 2022-01-24 오후 6 51 33" src="https://user-images.githubusercontent.com/73515587/150763764-a3eb6c76-dd1c-4bad-a732-e8daf5f08f25.png">

### 이미 해당 전시에 대해 리뷰를 달았을 경우
<img width="745" alt="스크린샷 2022-01-24 오후 6 51 45" src="https://user-images.githubusercontent.com/73515587/150763904-d10ba1b7-d74e-4d97-8155-bee2a3bac2ff.png">

### 전시회가 없을 경우
<img width="745" alt="스크린샷 2022-01-24 오후 6 52 12" src="https://user-images.githubusercontent.com/73515587/150763946-408efba9-bf31-4fc2-901d-54d243d77672.png">

### 사용자가 없을 경우
<img width="745" alt="스크린샷 2022-01-24 오후 6 52 52" src="https://user-images.githubusercontent.com/73515587/150763979-945fa5ef-3391-45c1-b9ef-2d6142dcf67a.png">
