### PR TITLE
[feat]유저 닉네임 변경/비밀번호 변경 기능 추가(#43)

### DIFF
--- a/src/main/java/hyangyu/server/api/AuthController.java
+++ b/src/main/java/hyangyu/server/api/AuthController.java
@@ -1,5 +1,6 @@
 package hyangyu.server.api;
 
+
 import hyangyu.server.dto.LoginDto;
 import hyangyu.server.dto.TokenDto;
 import hyangyu.server.jwt.JwtFilter;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Base64;
 
 import javax.validation.Valid;
 
@@ -45,4 +48,6 @@ public class AuthController {
 
         return new ResponseEntity<>(new TokenDto(jwt), httpHeaders, HttpStatus.OK);
     }
+    
+    
 }

--- a/src/main/java/hyangyu/server/api/AuthController.java
+++ b/src/main/java/hyangyu/server/api/AuthController.java
@@ -17,8 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Base64;
-
 import javax.validation.Valid;
 
 @RestController
@@ -48,6 +46,5 @@ public class AuthController {
 
         return new ResponseEntity<>(new TokenDto(jwt), httpHeaders, HttpStatus.OK);
     }
-    
     
 }

--- a/src/main/java/hyangyu/server/api/UserApi.java
+++ b/src/main/java/hyangyu/server/api/UserApi.java
@@ -40,8 +40,20 @@ public class UserApi {
     }
 
     @GetMapping("/user/{email}")
-    @PreAuthorize("hasAnyRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     public ResponseEntity<UserDto> getUserInfo(@PathVariable String email) {
         return ResponseEntity.ok(userService.getUserWithAuthorities(email));
+    }
+    
+    @PostMapping("/user/modifyUsername")
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    public ResponseEntity<String> modifyUsername(HttpServletRequest request, String username){
+    	UserDto userDto = userService.getMyUserWithAuthorities();
+    	return ResponseEntity.ok(userService.modifyUsername(userDto, username));
+    }
+    
+    @PostMapping("/user/modifyPassword")
+    public ResponseEntity<String> modifyUsername(@PathVariable String email, String password){
+    	return ResponseEntity.ok(userService.modifyPassword(email, password));
     }
 }

--- a/src/main/java/hyangyu/server/api/UserApi.java
+++ b/src/main/java/hyangyu/server/api/UserApi.java
@@ -40,7 +40,7 @@ public class UserApi {
     }
 
     @GetMapping("/user/{email}")
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<UserDto> getUserInfo(@PathVariable String email) {
         return ResponseEntity.ok(userService.getUserWithAuthorities(email));
     }

--- a/src/main/java/hyangyu/server/api/UserApi.java
+++ b/src/main/java/hyangyu/server/api/UserApi.java
@@ -53,7 +53,7 @@ public class UserApi {
     }
     
     @PostMapping("/user/modifyPassword")
-    public ResponseEntity<String> modifyUsername(@PathVariable String email, String password){
+    public ResponseEntity<String> modifyPassword(@PathVariable String email, String password){
     	return ResponseEntity.ok(userService.modifyPassword(email, password));
     }
 }

--- a/src/main/java/hyangyu/server/domain/User.java
+++ b/src/main/java/hyangyu/server/domain/User.java
@@ -67,5 +67,13 @@ public class User {
 
 		return user;
 	}
+	
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	
+	public void setUsername(String username) {
+		this.username = username;
+	}
 			
 }

--- a/src/main/java/hyangyu/server/service/UserService.java
+++ b/src/main/java/hyangyu/server/service/UserService.java
@@ -44,6 +44,22 @@ public class UserService {
 
         return UserDto.from(userRepository.save(user));
     }
+    
+    @Transactional
+    public String modifyUsername(UserDto userDto, String username) {
+    	User userEntity = userRepository.findByEmail(userDto.getEmail()).orElseThrow(() ->new IllegalArgumentException("해당 회원이 없습니다."));
+    	userEntity.setUsername(username);
+    	
+    	return username;
+    }
+    
+    @Transactional
+    public String modifyPassword(String email, String password) {
+    	User userEntity = userRepository.findByEmail(email).orElseThrow(() ->new IllegalArgumentException("해당 회원이 없습니다."));
+    	userEntity.setPassword(passwordEncoder.encode(password));
+    	
+    	return email;
+    }
 
     @Transactional(readOnly = true)
     public UserDto getUserWithAuthorities(String email) {


### PR DESCRIPTION
> UserService에 닉네임 변경/비밀번호 변경 기능 추가 및 UserApi에 연결했습니다.
닉네임 변경 같은 경우엔 HttpServletRequest로 jwt토큰을 받은 후 토큰을 해독해서 사용자의 이메일을 확인합니다.
이를 UserService에 있는 modifyUsername을 호출해서 유저네임을 변경할 수 있도록 합니다.

> 비밀번호 변경의 경우에는 Email을 직접 전달받기때문에, email로 유저를 검색한 후 암호화된 비밀번호로 다시 설정하도록 코드를 작성하였습니다.
하지만 이메일만으로 비밀번호를 변경하면 안되므로 후에 해당하는 email로 인증번호를 보낸 후 맞은 경우에만 수정 가능하도록 할 필요가 있습니다~

Close #43