### PR TITLE
[이벤트] 내가 저장한 전시/박람회/페스티벌 삭제 API

### DIFF
--- a/src/main/java/hyangyu/server/api/FavoriteApi.java
+++ b/src/main/java/hyangyu/server/api/FavoriteApi.java
@@ -3,16 +3,13 @@ package hyangyu.server.api;
 import hyangyu.server.domain.*;
 import hyangyu.server.dto.ErrorDto;
 import hyangyu.server.dto.EventDto;
-import hyangyu.server.dto.SaveFavoriteResponseDto;
+import hyangyu.server.dto.ResponseDto;
 import hyangyu.server.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -33,7 +30,7 @@ public class FavoriteApi {
     private final UserService userService;
 
     @PostMapping("/display/{displayId}")
-    public ResponseEntity saveDisplay(@PathVariable Long displayId) throws Exception {
+    public ResponseEntity saveFavoriteDisplay(@PathVariable Long displayId) throws Exception {
         //jwt 해독하는 코드 나오면 추후 수정
         Long userId = 1L;
         HttpHeaders httpHeaders = new HttpHeaders();
@@ -56,12 +53,12 @@ public class FavoriteApi {
             return new ResponseEntity(new ErrorDto(404, "이미 저장한 전시회입니다."), HttpStatus.BAD_REQUEST);
         }
 
-        SaveFavoriteResponseDto saveFavoriteResponseDto = new SaveFavoriteResponseDto(200, "내가 저장한 전시회에 추가되었습니다.");
-        return new ResponseEntity<>(saveFavoriteResponseDto, httpHeaders, HttpStatus.OK);
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 전시회에 추가되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
     }
 
     @PostMapping("/fair/{fairId}")
-    public ResponseEntity saveFair(@PathVariable Long fairId) throws Exception {
+    public ResponseEntity saveFavoriteFair(@PathVariable Long fairId) throws Exception {
         Long userId = 1L;
         HttpHeaders httpHeaders = new HttpHeaders();
 
@@ -87,18 +84,14 @@ public class FavoriteApi {
             return new ResponseEntity(new ErrorDto(404, "이미 저장한 박람회입니다."), HttpStatus.BAD_REQUEST);
         }
 
-        SaveFavoriteResponseDto saveFavoriteResponseDto = new SaveFavoriteResponseDto(200, "내가 저장한 박람회에 추가되었습니다.");
-        return new ResponseEntity<>(saveFavoriteResponseDto, httpHeaders, HttpStatus.OK);
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 박람회에 추가되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
     }
 
     @PostMapping("/festival/{festivalId}")
-    public ResponseEntity saveFestival(@PathVariable Long festivalId) throws Exception {
+    public ResponseEntity saveFavoriteFestival(@PathVariable Long festivalId) throws Exception {
         Long userId = 1L;
         HttpHeaders httpHeaders = new HttpHeaders();
-
-        EventDto eventDto = new EventDto(Date.valueOf("2021-01-24"), Date.valueOf("2021-01-28"), "테스트 페스티벌", 5, 0, Time.valueOf("09:00:00"), Time.valueOf("18:00:00"), Time.valueOf("09:00:00"), Time.valueOf("18:00:00"), "서울", "향유페스티벌", "매주 일요일", "세부내용", "", "", "", 0);
-        Festival f = Festival.createFestival(eventDto);
-        festivalService.saveFestival(f);
 
         //박람회 검색
         Optional<Festival> festival = festivalService.findOne(festivalId);
@@ -118,7 +111,89 @@ public class FavoriteApi {
             return new ResponseEntity(new ErrorDto(404, "이미 저장한 페스티벌입니다."), HttpStatus.BAD_REQUEST);
         }
 
-        SaveFavoriteResponseDto saveFavoriteResponseDto = new SaveFavoriteResponseDto(200, "내가 저장한 페스티벌에 추가되었습니다.");
-        return new ResponseEntity<>(saveFavoriteResponseDto, httpHeaders, HttpStatus.OK);
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 페스티벌에 추가되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
     }
+
+    @DeleteMapping("/display/{displayId}")
+    public ResponseEntity deleteFavoriteDisplay(@PathVariable Long displayId) throws Exception {
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //전시 검색
+        Optional<Display> display = displayService.findOne(displayId);
+        if(display.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 전시 id입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if(user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //저장한 전시회 검색
+        Optional<FavoriteDisplay> favoriteDisplay = favoriteDisplayService.deleteFavoriteDisplay(userId, displayId);
+        if(favoriteDisplay.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "저장하지 않은 전시회입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 전시회에서 삭제되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/fair/{fairId}")
+    public ResponseEntity deleteFavoriteFair(@PathVariable Long fairId) throws Exception {
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //전시 검색
+        Optional<Fair> fair = fairService.findOne(fairId);
+        if(fair.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 박람회 id입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if(user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //저장한 전시회 검색
+        Optional<FavoriteFair> favoriteFair = favoriteFairService.deleteFavoriteFair(userId, fairId);
+        if(favoriteFair.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "저장하지 않은 박람회입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 박람회에서 삭제되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/festival/{festivalId}")
+    public ResponseEntity deleteFavoriteFestival(@PathVariable Long festivalId) throws Exception {
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //전시 검색
+        Optional<Festival> festival = festivalService.findOne(festivalId);
+        if(festival.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 페스티벌 id입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if(user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //저장한 전시회 검색
+        Optional<FavoriteFestival> favoriteFestival = favoriteFestivalService.deleteFavoriteFestival(userId, festivalId);
+        if(favoriteFestival.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "저장하지 않은 페스티벌입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        ResponseDto responseDto = new ResponseDto(200, "내가 저장한 페스티벌에서 삭제되었습니다.");
+        return new ResponseEntity<>(responseDto, httpHeaders, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/hyangyu/server/domain/DisplayReview.java
+++ b/src/main/java/hyangyu/server/domain/DisplayReview.java
@@ -16,12 +16,12 @@ public class DisplayReview {
     @GeneratedValue
     private Long reviewId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @NotNull
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "display_id")
     @NotNull
     private Display display;

--- a/src/main/java/hyangyu/server/domain/FairReview.java
+++ b/src/main/java/hyangyu/server/domain/FairReview.java
@@ -19,12 +19,12 @@ public class FairReview {
     @GeneratedValue
     private Long reviewId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @NotNull
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fair_id")
     @NotNull
     private Fair fair;

--- a/src/main/java/hyangyu/server/domain/FavoriteDisplay.java
+++ b/src/main/java/hyangyu/server/domain/FavoriteDisplay.java
@@ -14,12 +14,12 @@ public class FavoriteDisplay {
     @EmbeddedId
     private FavoriteDisplayId favoriteDisplayId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("userId")
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("displayId")
     @JoinColumn(name = "display_id")
     private Display display;

--- a/src/main/java/hyangyu/server/domain/FavoriteFair.java
+++ b/src/main/java/hyangyu/server/domain/FavoriteFair.java
@@ -14,12 +14,12 @@ public class FavoriteFair {
     @EmbeddedId
     private FavoriteFairId favoriteFairId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("userId")
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("fairId")
     @JoinColumn(name = "fair_id")
     private Fair fair;

--- a/src/main/java/hyangyu/server/domain/FavoriteFestival.java
+++ b/src/main/java/hyangyu/server/domain/FavoriteFestival.java
@@ -15,12 +15,12 @@ public class FavoriteFestival {
     @EmbeddedId
     private FavoriteFestivalId favoriteFestivalId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("userId")
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("festivalId")
     @JoinColumn(name = "festival_id")
     private Festival festival;

--- a/src/main/java/hyangyu/server/domain/FestivalReview.java
+++ b/src/main/java/hyangyu/server/domain/FestivalReview.java
@@ -19,12 +19,12 @@ public class FestivalReview {
     @GeneratedValue
     private Long reviewId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @NotNull
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id")
     @NotNull
     private Festival festival;

--- a/src/main/java/hyangyu/server/dto/ResponseDto.java
+++ b/src/main/java/hyangyu/server/dto/ResponseDto.java
@@ -1,12 +1,11 @@
 package hyangyu.server.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class SaveFavoriteResponseDto {
+public class ResponseDto {
     int status;
     String message;
 }

--- a/src/main/java/hyangyu/server/repository/FavoriteDisplayRepository.java
+++ b/src/main/java/hyangyu/server/repository/FavoriteDisplayRepository.java
@@ -20,4 +20,6 @@ public class FavoriteDisplayRepository {
         return em.find(FavoriteDisplay.class, favoriteDisplayId);
     }
 
+    public void deleteFavoriteDisplay(FavoriteDisplay favoriteDisplay) { em.remove(em.find(FavoriteDisplay.class, favoriteDisplay.getFavoriteDisplayId()));}
+
 }

--- a/src/main/java/hyangyu/server/repository/FavoriteFairRepository.java
+++ b/src/main/java/hyangyu/server/repository/FavoriteFairRepository.java
@@ -1,5 +1,6 @@
 package hyangyu.server.repository;
 
+import hyangyu.server.domain.FavoriteDisplay;
 import hyangyu.server.domain.FavoriteFair;
 import hyangyu.server.domain.FavoriteFairId;
 import lombok.RequiredArgsConstructor;
@@ -20,4 +21,6 @@ public class FavoriteFairRepository {
     public FavoriteFair findOne(FavoriteFairId favoriteFairId) {
         return em.find(FavoriteFair.class, favoriteFairId);
     }
+
+    public void deleteFavoriteFair(FavoriteFair favoriteFair) { em.remove(em.find(FavoriteFair.class, favoriteFair.getFavoriteFairId()));}
 }

--- a/src/main/java/hyangyu/server/repository/FavoriteFestivalRepository.java
+++ b/src/main/java/hyangyu/server/repository/FavoriteFestivalRepository.java
@@ -1,5 +1,6 @@
 package hyangyu.server.repository;
 
+import hyangyu.server.domain.FavoriteDisplay;
 import hyangyu.server.domain.FavoriteFestival;
 import hyangyu.server.domain.FavoriteFestivalId;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +20,6 @@ public class FavoriteFestivalRepository {
     public FavoriteFestival findOne(FavoriteFestivalId favoriteFestivalId) {
         return em.find(FavoriteFestival.class, favoriteFestivalId);
     }
+
+    public void deleteFavoriteFestival(FavoriteFestival favoriteFestival) { em.remove(em.find(FavoriteFestival.class, favoriteFestival.getFavoriteFestivalId()));}
 }

--- a/src/main/java/hyangyu/server/service/FavoriteDisplayService.java
+++ b/src/main/java/hyangyu/server/service/FavoriteDisplayService.java
@@ -32,4 +32,16 @@ public class FavoriteDisplayService {
         }
         return result;
     }
+
+    @Transactional(readOnly = false)
+    public Optional<FavoriteDisplay> deleteFavoriteDisplay(Long userId, Long displayId) {
+        Optional<User> user = userRepository.findByUserId(userId);
+        Optional<Display> display = displayRepository.findOne(displayId);
+        FavoriteDisplay favoriteDisplay = new FavoriteDisplay(user.get(), display.get());
+        Optional<FavoriteDisplay> result = Optional.ofNullable(favoriteDisplayRepository.findOne(favoriteDisplay.getFavoriteDisplayId()));
+        if (result.isPresent()) {
+            favoriteDisplayRepository.deleteFavoriteDisplay(favoriteDisplay);
+        }
+        return result;
+    }
 }

--- a/src/main/java/hyangyu/server/service/FavoriteFairService.java
+++ b/src/main/java/hyangyu/server/service/FavoriteFairService.java
@@ -30,4 +30,16 @@ public class FavoriteFairService {
         }
         return result;
     }
+
+    @Transactional(readOnly = false)
+    public Optional<FavoriteFair> deleteFavoriteFair(Long userId, Long fairId) {
+        Optional<User> user = userRepository.findByUserId(userId);
+        Optional<Fair> fair = fairRepository.findOne(fairId);
+        FavoriteFair favoriteFair = new FavoriteFair(user.get(), fair.get());
+        Optional<FavoriteFair> result = Optional.ofNullable(favoriteFairRepository.findOne(favoriteFair.getFavoriteFairId()));
+        if (result.isPresent()) {
+            favoriteFairRepository.deleteFavoriteFair(favoriteFair);
+        }
+        return result;
+    }
 }

--- a/src/main/java/hyangyu/server/service/FavoriteFestivalService.java
+++ b/src/main/java/hyangyu/server/service/FavoriteFestivalService.java
@@ -1,10 +1,8 @@
 package hyangyu.server.service;
 
 
+import hyangyu.server.domain.*;
 import hyangyu.server.domain.Festival;
-import hyangyu.server.domain.FavoriteFestival;
-import hyangyu.server.domain.Festival;
-import hyangyu.server.domain.User;
 import hyangyu.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +27,18 @@ public class FavoriteFestivalService {
         Optional<FavoriteFestival> result = Optional.ofNullable(favoriteFestivalRepository.findOne(favoriteFestival.getFavoriteFestivalId()));
         if (result.isEmpty()) {
             favoriteFestivalRepository.saveFavoriteFestival(favoriteFestival);
+        }
+        return result;
+    }
+
+    @Transactional(readOnly = false)
+    public Optional<FavoriteFestival> deleteFavoriteFestival(Long userId, Long festivalId) {
+        Optional<User> user = userRepository.findByUserId(userId);
+        Optional<Festival> festival = festivalRepository.findOne(festivalId);
+        FavoriteFestival favoriteFestival = new FavoriteFestival(user.get(), festival.get());
+        Optional<FavoriteFestival> result = Optional.ofNullable(favoriteFestivalRepository.findOne(favoriteFestival.getFavoriteFestivalId()));
+        if (result.isPresent()) {
+            favoriteFestivalRepository.deleteFavoriteFestival(favoriteFestival);
         }
         return result;
     }


### PR DESCRIPTION
# 내가 저장한 전시/박람회/페스티벌 삭제 API
## 변경사항
1. cascade 설정 삭제
2. ResponseDt를 생성 (통합 response)
status code랑 message만 리턴해주는 통합 dto입니다~



## 포스트맨 테스트
<img width="1013" alt="스크린샷 2022-01-30 오후 10 06 26" src="https://user-images.githubusercontent.com/71828832/151702575-ffca9cf0-e685-4d49-9084-fee47137928d.png">
<img width="1014" alt="스크린샷 2022-01-30 오후 10 06 33" src="https://user-images.githubusercontent.com/71828832/151702579-9ed2ad81-9c52-45e5-93da-dab9c904f4e4.png">
<img width="1014" alt="스크린샷 2022-01-30 오후 10 06 41" src="https://user-images.githubusercontent.com/71828832/151702581-464185f0-cdab-4a2c-87df-5f6c1f9391bc.png">

빠른 개발을 위해 테스트는 건너뛰겠습니다...
박람회,페스티벌도 테스트 했습니다 캡쳐본은 생략~
DB 확인까지 완료!


jwt 필터링하는거는 userDto에 userId 추가되면 바로 할게요~~

