### PR TITLE
[feat] 전시, 박람회, 페스티벌 리뷰 삭제 api

### DIFF
--- a/src/main/java/hyangyu/server/api/ReviewApi.java
+++ b/src/main/java/hyangyu/server/api/ReviewApi.java
@@ -3,6 +3,7 @@ package hyangyu.server.api;
 import hyangyu.server.domain.*;
 import hyangyu.server.dto.ErrorDto;
 import hyangyu.server.dto.RequestReviewDto;
+import hyangyu.server.dto.ResponseDto;
 import hyangyu.server.dto.SaveReviewResponseDto;
 import hyangyu.server.service.*;
 import lombok.RequiredArgsConstructor;
@@ -218,6 +219,87 @@ public class ReviewApi {
         } else {
             SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 수정이 완료되었습니다.");
             return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
+        }
+    }
+
+    @DeleteMapping("/review/display/{displayId}")
+    public ResponseEntity deleteDisplayReview(@PathVariable Long displayId) throws Exception {
+        // jwt 해독 코드 추후 추가
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //전시 검색
+        Optional<Display> display = displayService.findOne(displayId);
+        if (display.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 전시 번호입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if (user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        Optional<DisplayReview> displayReview = displayReviewService.deleteDisplayReview(userId, displayId);
+        if (displayReview.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "삭제할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 삭제가 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
+        }
+    }
+
+    @DeleteMapping("/review/fair/{fairId}")
+    public ResponseEntity deleteFairReview(@PathVariable Long fairId) throws Exception {
+        // jwt 해독 코드 추후 추가
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //박람회 검색
+        Optional<Fair> fair = fairService.findOne(fairId);
+        if (fair.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 박람회 번호입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if (user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        Optional<FairReview> fairReview = fairReviewService.deleteFairReview(userId, fairId);
+        if (fairReview.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "삭제할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 삭제가 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
+        }
+    }
+
+    @DeleteMapping("/review/festival/{festivalId}")
+    public ResponseEntity deleteFestivalReview(@PathVariable Long festivalId) throws Exception {
+        // jwt 해독 코드 추후 추가
+        Long userId = 1L;
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        //페스티벌 검색
+        Optional<Festival> festival = festivalService.findOne(festivalId);
+        if (festival.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "잘못된 페스티벌 번호입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        //사용자 검색
+        Optional<User> user = userService.findUser(userId);
+        if (user.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(401, "유효하지 않은 사용자입니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        Optional<FestivalReview> festivalReview = festivalReviewService.deleteFestivalReview(userId, festivalId);
+        if (festivalReview.isEmpty()) {
+            return new ResponseEntity(new ErrorDto(404, "삭제할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 삭제가 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
         }
     }
 }

--- a/src/main/java/hyangyu/server/service/DisplayReviewService.java
+++ b/src/main/java/hyangyu/server/service/DisplayReviewService.java
@@ -42,4 +42,11 @@ public class DisplayReviewService {
         displayReview.ifPresent(review -> review.updateDisplayReview(requestReviewDto.getContent(), requestReviewDto.getScore()));
         return displayReview;
     }
+
+    @Transactional
+    public Optional<DisplayReview> deleteDisplayReview(Long userId, Long displayId) {
+        Optional<DisplayReview> displayReview = Optional.ofNullable(displayReviewRepository.getDisplayReview(displayId, userId));
+        displayReview.ifPresent(displayReviewRepository::delete);
+        return displayReview;
+    }
 }

--- a/src/main/java/hyangyu/server/service/FairReviewService.java
+++ b/src/main/java/hyangyu/server/service/FairReviewService.java
@@ -41,4 +41,11 @@ public class FairReviewService {
         fairReview.ifPresent(review -> review.updateFairReview(requestReviewDto.getContent(), requestReviewDto.getScore()));
         return fairReview;
     }
+
+    @Transactional
+    public Optional<FairReview> deleteFairReview(Long userId, Long fairId) {
+        Optional<FairReview> fairReview = Optional.ofNullable(fairReviewRepository.getFairReview(fairId, userId));
+        fairReview.ifPresent(fairReviewRepository::delete);
+        return fairReview;
+    }
 }

--- a/src/main/java/hyangyu/server/service/FestivalReviewService.java
+++ b/src/main/java/hyangyu/server/service/FestivalReviewService.java
@@ -41,4 +41,11 @@ public class FestivalReviewService {
         festivalReview.ifPresent(review -> review.updateFestivalReview(requestReviewDto.getContent(), requestReviewDto.getScore()));
         return festivalReview;
     }
+
+    @Transactional
+    public Optional<FestivalReview> deleteFestivalReview(Long userId, Long festivalId) {
+        Optional<FestivalReview> festivalReview = Optional.ofNullable(festivalReviewRepository.getFestivalReview(festivalId, userId));
+        festivalReview.ifPresent(festivalReviewRepository::delete);
+        return festivalReview;
+    }
 }

--- a/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
@@ -73,4 +73,27 @@ class DisplayReviewTest {
         assertThat(updatedDisplayReview.getContent()).isEqualTo("수정된 내용");
         assertThat(updatedDisplayReview.getScore()).isEqualTo(3);
     }
+
+    @Test
+    @DisplayName("전시회 리뷰 삭제")
+    void deleteDisplayReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "전시제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", "매주 월요일", "내용", "사진1", "사진2", "사진3", 20000);
+        Display display = Display.createDisplay(eventDto);
+        em.persist(display);
+
+        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        displayReviewRepository.save(displayReview);
+
+        //when
+        DisplayReview findDisplayReview = displayReviewRepository.getDisplayReview(display.getDisplayId(), user.getUserId());
+        displayReviewRepository.delete(findDisplayReview);
+        int count = displayReviewRepository.getCount(display.getDisplayId(), user.getUserId());
+
+        //then
+        assertThat(count).isEqualTo(0);
+    }
 }

--- a/src/test/java/hyangyu/server/repository/FairReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FairReviewTest.java
@@ -73,4 +73,27 @@ class FairReviewTest {
         assertThat(updatedFairReview.getContent()).isEqualTo("수정된 내용");
         assertThat(updatedFairReview.getScore()).isEqualTo(3);
     }
+
+    @Test
+    @DisplayName("박람회 리뷰 삭제")
+    void deleteFairReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", "매주 월요일", "내용", "사진1", "사진2", "사진3", 20000);
+        Fair fair = Fair.createFair(eventDto);
+        em.persist(fair);
+
+        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        fairReviewRepository.save(fairReview);
+
+        //when
+        FairReview findFairReview = fairReviewRepository.getFairReview(fair.getFairId(), user.getUserId());
+        fairReviewRepository.delete(findFairReview);
+        int count = fairReviewRepository.getCount(fair.getFairId(), user.getUserId());
+
+        //then
+        assertThat(count).isEqualTo(0);
+    }
 }

--- a/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
@@ -72,4 +72,27 @@ class FestivalReviewTest {
         assertThat(updatedFestivalReview.getContent()).isEqualTo("수정된 내용");
         assertThat(updatedFestivalReview.getScore()).isEqualTo(3);
     }
+
+    @Test
+    @DisplayName("페스티벌 리뷰 삭제")
+    void deleteFestivalReview() throws Exception {
+        //given
+        User user = User.createUser("test@naver.com", "test1234", "향유", "sub", "token", "image");
+        em.persist(user);
+
+        EventDto eventDto = new EventDto(Date.valueOf("2021-01-17"), Date.valueOf("2021-01-20"), "박람회제목", 2, 0, Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), Time.valueOf("09:00:00"), Time.valueOf("17:00:00"), "위치", "사이트주소", "매주 월요일", "내용", "사진1", "사진2", "사진3", 20000);
+        Festival festival = Festival.createFestival(eventDto);
+        em.persist(festival);
+
+        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        festivalReviewRepository.save(festivalReview);
+
+        //when
+        FestivalReview findFestivalReview = festivalReviewRepository.getFestivalReview(festival.getFestivalId(), user.getUserId());
+        festivalReviewRepository.delete(findFestivalReview);
+        int count = festivalReviewRepository.getCount(festival.getFestivalId(), user.getUserId());
+
+        //then
+        assertThat(count).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
리뷰 삭제 api 완료!

## 테스트
repository 테스트만 일단 작성했습니다
<img width="371" alt="스크린샷 2022-02-01 오후 8 38 12" src="https://user-images.githubusercontent.com/73515587/151963114-991c56c5-9a01-47ee-b6bf-2fc50959e479.png">
<img width="371" alt="스크린샷 2022-02-01 오후 8 38 59" src="https://user-images.githubusercontent.com/73515587/151963125-0dd2edc7-f438-41d4-93b2-3e15af8c6f57.png">
<img width="371" alt="스크린샷 2022-02-01 오후 8 40 40" src="https://user-images.githubusercontent.com/73515587/151963129-6245c1e5-9e36-470c-a291-9cf648f7e906.png">

## 포스트맨 테스트
### 리뷰 삭제 성공
<img width="742" alt="스크린샷 2022-02-01 오후 8 28 32" src="https://user-images.githubusercontent.com/73515587/151963190-e90e76ab-98f4-421b-bd30-2390df4a82a0.png">

### 삭제할 리뷰 없을 때
<img width="742" alt="스크린샷 2022-02-01 오후 8 28 39" src="https://user-images.githubusercontent.com/73515587/151963208-ebf8362f-415c-485f-8064-afa559bb5814.png">
박람회, 페스티벌도 동일한 결과 나오는 것 확인했고 캡처는 생략하겠습니다~
