### PR TITLE
[fix] 리뷰 저장 api 수정

### DIFF
--- a/src/main/java/hyangyu/server/api/ReviewApi.java
+++ b/src/main/java/hyangyu/server/api/ReviewApi.java
@@ -46,12 +46,12 @@ public class ReviewApi {
             return new ResponseEntity(new ErrorDto(404, "리뷰 길이가 300자를 초과합니다."), HttpStatus.BAD_REQUEST);
         }
 
-        int count = displayReviewService.saveDisplayReview(user.getUserId(), displayId, requestReviewDto);
-        if (count == 0) {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
-        } else {
+        Long reviewId = displayReviewService.saveDisplayReview(user.getUserId(), displayId, requestReviewDto);
+        if (reviewId == -1L) {
             return new ResponseEntity(new ErrorDto(404, "이미 전시에 대한 리뷰를 달았습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.", reviewId);
+            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -77,12 +77,12 @@ public class ReviewApi {
             return new ResponseEntity(new ErrorDto(404, "리뷰 길이가 300자를 초과합니다."), HttpStatus.BAD_REQUEST);
         }
 
-        int count = fairReviewService.saveFairReview(user.getUserId(), fairId, requestReviewDto);
-        if (count == 0) {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
-        } else {
+        Long reviewId = fairReviewService.saveFairReview(user.getUserId(), fairId, requestReviewDto);
+        if (reviewId == -1L) {
             return new ResponseEntity(new ErrorDto(404, "이미 박람회에 대한 리뷰를 달았습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.", reviewId);
+            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -108,12 +108,12 @@ public class ReviewApi {
             return new ResponseEntity(new ErrorDto(404, "리뷰 길이가 300자를 초과합니다."), HttpStatus.BAD_REQUEST);
         }
 
-        int count = festivalReviewService.saveFestivalReview(user.getUserId(), festivalId, requestReviewDto);
-        if (count == 0) {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
-        } else {
+        Long reviewId = festivalReviewService.saveFestivalReview(user.getUserId(), festivalId, requestReviewDto);
+        if (reviewId == -1L) {
             return new ResponseEntity(new ErrorDto(404, "이미 페스티벌에 대한 리뷰를 달았습니다."), HttpStatus.BAD_REQUEST);
+        } else {
+            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 작성이 완료되었습니다.", reviewId);
+            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -142,8 +142,8 @@ public class ReviewApi {
         if (displayReview.isEmpty()) {
             return new ResponseEntity(new ErrorDto(404, "수정할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
         } else {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 수정이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 수정이 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -172,8 +172,8 @@ public class ReviewApi {
         if (fairReview.isEmpty()) {
             return new ResponseEntity(new ErrorDto(404, "수정할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
         } else {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 수정이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 수정이 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -202,8 +202,8 @@ public class ReviewApi {
         if (festivalReview.isEmpty()) {
             return new ResponseEntity(new ErrorDto(404, "수정할 리뷰가 없습니다."), HttpStatus.BAD_REQUEST);
         } else {
-            SaveReviewResponseDto saveReviewResponseDto = new SaveReviewResponseDto(200, "리뷰 수정이 완료되었습니다.");
-            return new ResponseEntity(saveReviewResponseDto, httpHeaders, HttpStatus.OK);
+            ResponseDto responseDto = new ResponseDto(200, "리뷰 수정이 완료되었습니다.");
+            return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
         }
     }
 
@@ -281,4 +281,9 @@ public class ReviewApi {
             return new ResponseEntity(responseDto, httpHeaders, HttpStatus.OK);
         }
     }
+
+//    @PostMapping("/review/accuse/{eventId}/{userId}")
+//    public ResponseEntity accuseReview(@PathVariable Long eventId, @PathVariable Long userId, @RequestBody String event) throws Exception {
+//
+//    }
 }

--- a/src/main/java/hyangyu/server/domain/DisplayReview.java
+++ b/src/main/java/hyangyu/server/domain/DisplayReview.java
@@ -41,8 +41,11 @@ public class DisplayReview {
     @NotNull
     private Integer score;
 
+    @NotNull
+    private Integer warn;
+
     // 생성 메서드
-    public static DisplayReview createDisplayReview(User user, Display display, String nickname, LocalDateTime createTime, String content, Integer score) {
+    public static DisplayReview createDisplayReview(User user, Display display, String nickname, LocalDateTime createTime, String content, Integer score, Integer warn) {
         DisplayReview displayReview = new DisplayReview();
         displayReview.user = user;
         displayReview.display = display;
@@ -50,6 +53,7 @@ public class DisplayReview {
         displayReview.createTime = createTime;
         displayReview.content = content;
         displayReview.score = score;
+        displayReview.warn = warn;
         return displayReview;
     }
 

--- a/src/main/java/hyangyu/server/domain/FairReview.java
+++ b/src/main/java/hyangyu/server/domain/FairReview.java
@@ -44,8 +44,11 @@ public class FairReview {
     @NotNull
     private Integer score;
 
+    @NotNull
+    private Integer warn;
+
     // 생성 메서드
-    public static FairReview createFairReview(User user, Fair fair, String nickname, LocalDateTime createTime, String content, Integer score) {
+    public static FairReview createFairReview(User user, Fair fair, String nickname, LocalDateTime createTime, String content, Integer score, Integer warn) {
         FairReview fairReview = new FairReview();
         fairReview.user = user;
         fairReview.fair = fair;
@@ -53,6 +56,7 @@ public class FairReview {
         fairReview.createTime = createTime;
         fairReview.content = content;
         fairReview.score = score;
+        fairReview.warn = warn;
         return fairReview;
     }
 

--- a/src/main/java/hyangyu/server/domain/FestivalReview.java
+++ b/src/main/java/hyangyu/server/domain/FestivalReview.java
@@ -44,8 +44,11 @@ public class FestivalReview {
     @NotNull
     private Integer score;
 
+    @NotNull
+    private Integer warn;
+
     // 생성 메서드
-    public static FestivalReview createFestivalReview(User user, Festival festival, String nickname, LocalDateTime createTime, String content, Integer score) {
+    public static FestivalReview createFestivalReview(User user, Festival festival, String nickname, LocalDateTime createTime, String content, Integer score, Integer warn) {
         FestivalReview festivalReview = new FestivalReview();
         festivalReview.user = user;
         festivalReview.festival = festival;
@@ -53,6 +56,7 @@ public class FestivalReview {
         festivalReview.createTime = createTime;
         festivalReview.content = content;
         festivalReview.score = score;
+        festivalReview.warn = warn;
         return festivalReview;
     }
 

--- a/src/main/java/hyangyu/server/dto/SaveReviewResponseDto.java
+++ b/src/main/java/hyangyu/server/dto/SaveReviewResponseDto.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class SaveReviewResponseDto {
     int status;
     String message;
+    Long reviewId;
 }

--- a/src/main/java/hyangyu/server/service/DisplayReviewService.java
+++ b/src/main/java/hyangyu/server/service/DisplayReviewService.java
@@ -30,7 +30,7 @@ public class DisplayReviewService {
         Optional<Display> display = displayRepository.findOne(displayId);
         int count = displayReviewRepository.getCount(display.get().getDisplayId(), user.get().getUserId());
         if (count == 0) {
-            DisplayReview displayReview = DisplayReview.createDisplayReview(user.get(), display.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore());
+            DisplayReview displayReview = DisplayReview.createDisplayReview(user.get(), display.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
             displayReviewRepository.save(displayReview);
         }
         return count;

--- a/src/main/java/hyangyu/server/service/DisplayReviewService.java
+++ b/src/main/java/hyangyu/server/service/DisplayReviewService.java
@@ -25,15 +25,17 @@ public class DisplayReviewService {
     private final DisplayRepository displayRepository;
 
     @Transactional(readOnly = false)
-    public int saveDisplayReview(Long userId, Long displayId, RequestReviewDto requestReviewDto) {
+    public Long saveDisplayReview(Long userId, Long displayId, RequestReviewDto requestReviewDto) {
         Optional<User> user = userRepository.findById(userId);
         Optional<Display> display = displayRepository.findOne(displayId);
         int count = displayReviewRepository.getCount(display.get().getDisplayId(), user.get().getUserId());
         if (count == 0) {
             DisplayReview displayReview = DisplayReview.createDisplayReview(user.get(), display.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
-            displayReviewRepository.save(displayReview);
+            DisplayReview savedDisplayReview = displayReviewRepository.save(displayReview);
+            return savedDisplayReview.getReviewId();
+        } else {
+            return -1L;
         }
-        return count;
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/hyangyu/server/service/FairReviewService.java
+++ b/src/main/java/hyangyu/server/service/FairReviewService.java
@@ -29,7 +29,7 @@ public class FairReviewService {
         Optional<Fair> fair = fairRepository.findOne(fairId);
         int count = fairReviewRepository.getCount(fair.get().getFairId(), user.get().getUserId());
         if (count == 0) {
-            FairReview fairReview = FairReview.createFairReview(user.get(), fair.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore());
+            FairReview fairReview = FairReview.createFairReview(user.get(), fair.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
             fairReviewRepository.save(fairReview);
         }
         return count;

--- a/src/main/java/hyangyu/server/service/FairReviewService.java
+++ b/src/main/java/hyangyu/server/service/FairReviewService.java
@@ -24,15 +24,17 @@ public class FairReviewService {
     private final FairRepository fairRepository;
 
     @Transactional(readOnly = false)
-    public int saveFairReview(Long userId, Long fairId, RequestReviewDto requestReviewDto) {
+    public Long saveFairReview(Long userId, Long fairId, RequestReviewDto requestReviewDto) {
         Optional<User> user = userRepository.findById(userId);
         Optional<Fair> fair = fairRepository.findOne(fairId);
         int count = fairReviewRepository.getCount(fair.get().getFairId(), user.get().getUserId());
         if (count == 0) {
             FairReview fairReview = FairReview.createFairReview(user.get(), fair.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
-            fairReviewRepository.save(fairReview);
+            FairReview savedFairReview = fairReviewRepository.save(fairReview);
+            return savedFairReview.getReviewId();
+        } else {
+            return -1L;
         }
-        return count;
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/hyangyu/server/service/FestivalReviewService.java
+++ b/src/main/java/hyangyu/server/service/FestivalReviewService.java
@@ -24,15 +24,17 @@ public class FestivalReviewService {
     private final FestivalRepository festivalRepository;
 
     @Transactional(readOnly = false)
-    public int saveFestivalReview(Long userId, Long festivalId, RequestReviewDto requestReviewDto) {
+    public Long saveFestivalReview(Long userId, Long festivalId, RequestReviewDto requestReviewDto) {
         Optional<User> user = userRepository.findById(userId);
         Optional<Festival> festival = festivalRepository.findOne(festivalId);
         int count = festivalReviewRepository.getCount(festival.get().getFestivalId(), user.get().getUserId());
         if (count == 0) {
             FestivalReview festivalReview = FestivalReview.createFestivalReview(user.get(), festival.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
-            festivalReviewRepository.save(festivalReview);
+            FestivalReview savedFestivalReview = festivalReviewRepository.save(festivalReview);
+            return savedFestivalReview.getReviewId();
+        } else {
+            return -1L;
         }
-        return count;
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/hyangyu/server/service/FestivalReviewService.java
+++ b/src/main/java/hyangyu/server/service/FestivalReviewService.java
@@ -29,7 +29,7 @@ public class FestivalReviewService {
         Optional<Festival> festival = festivalRepository.findOne(festivalId);
         int count = festivalReviewRepository.getCount(festival.get().getFestivalId(), user.get().getUserId());
         if (count == 0) {
-            FestivalReview festivalReview = FestivalReview.createFestivalReview(user.get(), festival.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore());
+            FestivalReview festivalReview = FestivalReview.createFestivalReview(user.get(), festival.get(), user.get().getUsername(), LocalDateTime.now(), requestReviewDto.getContent(), requestReviewDto.getScore(), 0);
             festivalReviewRepository.save(festivalReview);
         }
         return count;

--- a/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/DisplayReviewTest.java
@@ -39,7 +39,7 @@ class DisplayReviewTest {
         em.persist(display);
 
         //when
-        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         DisplayReview savedDisplayReview = displayReviewRepository.save(displayReview);
         int count = displayReviewRepository.getCount(display.getDisplayId(), user.getUserId());
 
@@ -60,7 +60,7 @@ class DisplayReviewTest {
         Display display = Display.createDisplay(eventDto);
         em.persist(display);
 
-        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         DisplayReview savedDisplayReview = displayReviewRepository.save(displayReview);
 
         //when
@@ -85,7 +85,7 @@ class DisplayReviewTest {
         Display display = Display.createDisplay(eventDto);
         em.persist(display);
 
-        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        DisplayReview displayReview = DisplayReview.createDisplayReview(user, display, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         displayReviewRepository.save(displayReview);
 
         //when

--- a/src/test/java/hyangyu/server/repository/FairReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FairReviewTest.java
@@ -39,7 +39,7 @@ class FairReviewTest {
         em.persist(fair);
 
         //when
-        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         FairReview savedFairReview = fairReviewRepository.save(fairReview);
         int count = fairReviewRepository.getCount(fair.getFairId(), user.getUserId());
 
@@ -60,7 +60,7 @@ class FairReviewTest {
         Fair fair = Fair.createFair(eventDto);
         em.persist(fair);
 
-        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         FairReview savedFairReview = fairReviewRepository.save(fairReview);
 
         //when
@@ -85,7 +85,7 @@ class FairReviewTest {
         Fair fair = Fair.createFair(eventDto);
         em.persist(fair);
 
-        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FairReview fairReview = FairReview.createFairReview(user, fair, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         fairReviewRepository.save(fairReview);
 
         //when

--- a/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
+++ b/src/test/java/hyangyu/server/repository/FestivalReviewTest.java
@@ -38,7 +38,7 @@ class FestivalReviewTest {
         em.persist(festival);
 
         //when
-        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         FestivalReview savedFestivalReview = festivalReviewRepository.save(festivalReview);
         int count = festivalReviewRepository.getCount(festival.getFestivalId(), user.getUserId());
 
@@ -59,7 +59,7 @@ class FestivalReviewTest {
         Festival festival = Festival.createFestival(eventDto);
         em.persist(festival);
 
-        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         FestivalReview savedFestivalReview = festivalReviewRepository.save(festivalReview);
 
         //when
@@ -84,7 +84,7 @@ class FestivalReviewTest {
         Festival festival = Festival.createFestival(eventDto);
         em.persist(festival);
 
-        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5);
+        FestivalReview festivalReview = FestivalReview.createFestivalReview(user, festival, user.getUsername(), LocalDateTime.now(), "내용", 5, 0);
         festivalReviewRepository.save(festivalReview);
 
         //when


### PR DESCRIPTION
feat/#50 브랜치에서 작업하다가 fix/#61 브랜치 따로 파서 저장 api 쪽만 커밋했는데...
pr 날리니까 feat/#50 브랜치에서 작업한 것까지 날라가네유......일단 pr 날립니다

## 공지사항
리뷰 저장 시 리뷰아이디를 반환해서 프론트에서 리뷰아이디 저장할 수 있도록 바꿨습니다~~

## 포스트맨 테스트
### 전시
<img width="747" alt="스크린샷 2022-02-06 오후 11 44 00" src="https://user-images.githubusercontent.com/73515587/152686881-1ee379af-0a30-480b-b0dc-f873d4557eb0.png">

### 박람회
<img width="747" alt="스크린샷 2022-02-06 오후 11 52 39" src="https://user-images.githubusercontent.com/73515587/152686893-531b5d55-4580-4a38-902c-d5f810e11a29.png">

### 페스티벌
<img width="747" alt="스크린샷 2022-02-06 오후 11 52 35" src="https://user-images.githubusercontent.com/73515587/152686900-134c34c2-91e0-4abf-9b32-d7263bf647dc.png">
