### PR TITLE
[feat] 전시, 박람회, 페스티벌 검색 API

### DIFF
--- a/src/main/java/hyangyu/server/api/SearchApi.java
+++ b/src/main/java/hyangyu/server/api/SearchApi.java
@@ -1,0 +1,26 @@
+package hyangyu.server.api;
+
+import hyangyu.server.dto.event.SearchDto;
+import hyangyu.server.dto.event.SearchResponseDto;
+import hyangyu.server.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SearchApi {
+
+    private final SearchService searchService;
+
+    @GetMapping("/search")
+    public ResponseEntity getSearchDate() throws Exception {
+        SearchResponseDto searchData = searchService.getSearchData();
+        SearchDto searchDto = new SearchDto(200, searchData);
+        return new ResponseEntity(searchDto, HttpStatus.OK);
+    }
+}

--- a/src/main/java/hyangyu/server/config/SecurityConfig.java
+++ b/src/main/java/hyangyu/server/config/SecurityConfig.java
@@ -96,6 +96,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/show/review/display/{displayId}").permitAll()
                 .antMatchers("/api/show/review/fair/{fairId}").permitAll()
                 .antMatchers("/api/show/review/festival/{festivalId}").permitAll()
+                .antMatchers("/api/search").permitAll()
                 .anyRequest().authenticated()
 
                 .and()

--- a/src/main/java/hyangyu/server/dto/event/SearchDto.java
+++ b/src/main/java/hyangyu/server/dto/event/SearchDto.java
@@ -1,0 +1,11 @@
+package hyangyu.server.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SearchDto {
+    int status;
+    SearchResponseDto data;
+}

--- a/src/main/java/hyangyu/server/dto/event/SearchResponseDto.java
+++ b/src/main/java/hyangyu/server/dto/event/SearchResponseDto.java
@@ -1,0 +1,15 @@
+package hyangyu.server.dto.event;
+
+import hyangyu.server.dto.EventDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class SearchResponseDto {
+    List<EventDto> display;
+    List<EventDto> fair;
+    List<EventDto> festival;
+}

--- a/src/main/java/hyangyu/server/repository/DisplayRepository.java
+++ b/src/main/java/hyangyu/server/repository/DisplayRepository.java
@@ -41,35 +41,29 @@ public class DisplayRepository {
             displays = queryFactory.select(display)
                     .from(display)
                     .orderBy(display.startDate.desc())
-                    .offset(page*10)
+                    .offset(page * 10)
                     .limit(10)
                     .fetch();
 
-        }
-
-        else if (order.equals("popularity")) {
+        } else if (order.equals("popularity")) {
             displays = queryFactory.select(display)
                     .from(display)
                     .orderBy(display.likey.desc())
-                    .offset(page*10)
+                    .offset(page * 10)
                     .limit(10)
                     .fetch();
-        }
-
-        else if (order.equals("charge")) {
+        } else if (order.equals("charge")) {
             displays = queryFactory.select(display)
                     .from(display)
                     .where(display.price.gt(0))
-                    .offset(page*10)
+                    .offset(page * 10)
                     .limit(10)
                     .fetch();
-        }
-
-        else if (order.equals("free")) {
+        } else if (order.equals("free")) {
             displays = queryFactory.select(display)
                     .from(display)
                     .where(display.price.eq(0))
-                    .offset(page*10)
+                    .offset(page * 10)
                     .limit(10)
                     .fetch();
         }
@@ -82,5 +76,16 @@ public class DisplayRepository {
         }
 
         return new DisplayDto(displayList);
+    }
+
+    public List<EventDto> getAllDisplay() {
+        List<Display> display = em.createQuery("select d from Display d", Display.class)
+                .getResultList();
+        List<EventDto> resultList = new ArrayList<>();
+        for (Display d : display) {
+            resultList.add(new EventDto(d));
+        }
+
+        return resultList;
     }
 }

--- a/src/main/java/hyangyu/server/repository/FairRepository.java
+++ b/src/main/java/hyangyu/server/repository/FairRepository.java
@@ -1,10 +1,13 @@
 package hyangyu.server.repository;
 
 import hyangyu.server.domain.Fair;
+import hyangyu.server.dto.EventDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,5 +21,16 @@ public class FairRepository {
 
     public Optional<Fair> findOne(Long fairId) {
         return Optional.ofNullable(em.find(Fair.class, fairId));
+    }
+
+    public List<EventDto> getAllFair() {
+        List<Fair> fair = em.createQuery("select d from Fair d", Fair.class)
+                .getResultList();
+        List<EventDto> resultList = new ArrayList<>();
+        for (Fair d : fair) {
+            resultList.add(new EventDto(d));
+        }
+
+        return resultList;
     }
 }

--- a/src/main/java/hyangyu/server/repository/FestivalRepository.java
+++ b/src/main/java/hyangyu/server/repository/FestivalRepository.java
@@ -1,10 +1,14 @@
 package hyangyu.server.repository;
 
 import hyangyu.server.domain.Festival;
+import hyangyu.server.domain.Festival;
+import hyangyu.server.dto.EventDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,5 +23,16 @@ public class FestivalRepository {
 
     public Optional<Festival> findOne(Long festivalId) {
         return Optional.ofNullable(em.find(Festival.class, festivalId));
+    }
+
+    public List<EventDto> getAllFestival() {
+        List<Festival> festival = em.createQuery("select d from Festival d", Festival.class)
+                .getResultList();
+        List<EventDto> resultList = new ArrayList<>();
+        for (Festival d : festival) {
+            resultList.add(new EventDto(d));
+        }
+
+        return resultList;
     }
 }

--- a/src/main/java/hyangyu/server/service/SearchService.java
+++ b/src/main/java/hyangyu/server/service/SearchService.java
@@ -1,0 +1,30 @@
+package hyangyu.server.service;
+
+import hyangyu.server.dto.EventDto;
+import hyangyu.server.dto.event.DisplayDto;
+import hyangyu.server.dto.event.SearchResponseDto;
+import hyangyu.server.repository.DisplayRepository;
+import hyangyu.server.repository.FairRepository;
+import hyangyu.server.repository.FestivalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final DisplayRepository displayRepository;
+    private final FairRepository fairRepository;
+    private final FestivalRepository festivalRepository;
+
+    public SearchResponseDto getSearchData() {
+        List<EventDto> allDisplay = displayRepository.getAllDisplay();
+        List<EventDto> allFair = fairRepository.getAllFair();
+        List<EventDto> allFestival = festivalRepository.getAllFestival();
+        return new SearchResponseDto(allDisplay, allFair, allFestival);
+    }
+}


### PR DESCRIPTION
## 공지사항
급하게 개발하느라 이게 맞는지 모르겠는데.. 혹시 수정사항 있으면 말해주세요!!

## 포스트맨 테스트
<img width="904" alt="스크린샷 2022-02-10 오전 12 36 22" src="https://user-images.githubusercontent.com/73515587/153234948-26f69673-0575-4c94-baf0-55ba8a228a07.png">
<img width="904" alt="스크린샷 2022-02-10 오전 12 36 35" src="https://user-images.githubusercontent.com/73515587/153234956-357fb591-c8de-4ad3-b661-205118f1e370.png">
<img width="904" alt="스크린샷 2022-02-10 오전 12 36 41" src="https://user-images.githubusercontent.com/73515587/153234960-8d268ec5-ff64-4adc-87fc-ff97f0299ccd.png">
display, fair, festival 별로 나눠서 데이터 다 전송해줍니다!